### PR TITLE
관리자 페이지 관리자 관련 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'me.paulschwarz:spring-dotenv:2.5.4'
     implementation 'me.paulschwarz:spring-dotenv:2.5.4'
+    implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 
 	//db
 	runtimeOnly   'com.mysql:mysql-connector-j'

--- a/src/main/java/com/momeokji/aiDiarybackend/common/util/JwtUtil.java
+++ b/src/main/java/com/momeokji/aiDiarybackend/common/util/JwtUtil.java
@@ -9,6 +9,7 @@ import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.momeokji.aiDiarybackend.entity.Admin;
 import com.momeokji.aiDiarybackend.entity.Member;
 
 import io.jsonwebtoken.*;
@@ -41,12 +42,33 @@ public class JwtUtil {
 		return createToken(member, "REFRESH", refreshExpMs);
 	}
 
+	public String generateAdminAccessToken(Admin admin){
+		return createAdminToken(admin, "ACCESS", accessExpMs);
+	}
+
+	public String generateAdminRefreshToken(Admin admin){
+		return createAdminToken(admin, "REFRESH", refreshExpMs);
+	}
+
 	private String createToken(Member member, String typ, long expMs) {
 		long now = System.currentTimeMillis();
 		return Jwts.builder()
 			.issuer(issuer)
 			.subject(member.getMemberId()) // sub = memberId
 			.claims(Map.of("did", member.getDeviceId(), "typ", typ))
+			.issuedAt(new Date(now))
+			.expiration(new Date(now + expMs))
+			.signWith(key(), Jwts.SIG.HS256)
+			.compact();
+	}
+
+	private String createAdminToken(Admin admin, String typ, long expMs) {
+		long now = System.currentTimeMillis();
+		String role = Boolean.TRUE.equals(admin.getIsSuper()) ? "SUPER_ADMIN" : "ADMIN";
+		return Jwts.builder()
+			.issuer(issuer)
+			.subject(admin.getAdminId()) // sub = adminId
+			.claims(Map.of("typ", typ, "role", role))
 			.issuedAt(new Date(now))
 			.expiration(new Date(now + expMs))
 			.signWith(key(), Jwts.SIG.HS256)

--- a/src/main/java/com/momeokji/aiDiarybackend/config/SecurityConfig.java
+++ b/src/main/java/com/momeokji/aiDiarybackend/config/SecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -28,6 +30,8 @@ public class SecurityConfig {
 			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(HttpMethod.POST, "/users").permitAll()
+				.requestMatchers(HttpMethod.POST, "/admins").permitAll()
+				.requestMatchers(HttpMethod.POST, "/admins/login").permitAll()
 				.requestMatchers( "/auth/refresh","/auth/login","/error", "/error/**", "/health").permitAll()
 				.anyRequest().authenticated()
 			)
@@ -35,6 +39,11 @@ public class SecurityConfig {
 		return http.build();
 	}
 
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
 
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {

--- a/src/main/java/com/momeokji/aiDiarybackend/controller/AdminAuthController.java
+++ b/src/main/java/com/momeokji/aiDiarybackend/controller/AdminAuthController.java
@@ -1,0 +1,70 @@
+package com.momeokji.aiDiarybackend.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.momeokji.aiDiarybackend.dto.request.AdminApproveRequestDto;
+import com.momeokji.aiDiarybackend.dto.request.AdminSignupRequestDto;
+import com.momeokji.aiDiarybackend.dto.response.AdminLoginResponseDto;
+import com.momeokji.aiDiarybackend.dto.response.AdminLoginResultDto;
+import com.momeokji.aiDiarybackend.dto.response.AdminResponseDto;
+import com.momeokji.aiDiarybackend.service.AdminAuthService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminAuthController {
+
+	private final AdminAuthService adminAuthService;
+
+	@PostMapping("/admins")
+	public ResponseEntity<Void> signup(@Validated @RequestBody AdminSignupRequestDto req) {
+		adminAuthService.signup(req);
+		return ResponseEntity.noContent().build();
+	}
+
+	@PostMapping("/admins/login")
+	public ResponseEntity<AdminLoginResponseDto> login(@Validated @RequestBody AdminSignupRequestDto req) {
+		AdminLoginResultDto result = adminAuthService.login(req);
+
+		return ResponseEntity.ok()
+			.header(HttpHeaders.AUTHORIZATION, "Bearer " + result.getAccessToken())
+			.header("Refresh-Token", result.getRefreshToken())
+			.body(AdminLoginResponseDto.builder()
+				.isSuper(result.getIsSuper())
+				.build());
+	}
+
+	@PostMapping("/admins/approve")
+	public ResponseEntity<Void> approveAdmin(
+		@Validated @RequestBody AdminApproveRequestDto req,
+		Authentication auth
+	) {
+		adminAuthService.approveAdmin(auth.getName(), req.getAdminId());
+		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/admins")
+	public ResponseEntity<List<AdminResponseDto>> getAdmins(Authentication auth) {
+		return ResponseEntity.ok(adminAuthService.getAdmins(auth.getName()));
+	}
+
+	@DeleteMapping("/admins")
+	public ResponseEntity<Void> deleteAdmin(
+		@Validated @RequestBody AdminApproveRequestDto req,
+		Authentication auth
+	) {
+		adminAuthService.deleteAdmin(auth.getName(), req.getAdminId());
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/momeokji/aiDiarybackend/dto/request/AdminApproveRequestDto.java
+++ b/src/main/java/com/momeokji/aiDiarybackend/dto/request/AdminApproveRequestDto.java
@@ -1,0 +1,11 @@
+package com.momeokji.aiDiarybackend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class AdminApproveRequestDto {
+
+	@NotBlank(message = "adminId는 필수입니다.")
+	private String adminId;
+}

--- a/src/main/java/com/momeokji/aiDiarybackend/dto/request/AdminSignupRequestDto.java
+++ b/src/main/java/com/momeokji/aiDiarybackend/dto/request/AdminSignupRequestDto.java
@@ -1,0 +1,14 @@
+package com.momeokji.aiDiarybackend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class AdminSignupRequestDto {
+
+	@NotBlank(message = "adminId는 필수입니다.")
+	private String adminId;
+
+	@NotBlank(message = "adminPwd는 필수입니다.")
+	private String adminPwd;
+}

--- a/src/main/java/com/momeokji/aiDiarybackend/dto/response/AdminLoginResponseDto.java
+++ b/src/main/java/com/momeokji/aiDiarybackend/dto/response/AdminLoginResponseDto.java
@@ -1,0 +1,11 @@
+package com.momeokji.aiDiarybackend.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminLoginResponseDto {
+
+	private Boolean isSuper;
+}

--- a/src/main/java/com/momeokji/aiDiarybackend/dto/response/AdminLoginResultDto.java
+++ b/src/main/java/com/momeokji/aiDiarybackend/dto/response/AdminLoginResultDto.java
@@ -1,0 +1,13 @@
+package com.momeokji.aiDiarybackend.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminLoginResultDto {
+
+	private String accessToken;
+	private String refreshToken;
+	private Boolean isSuper;
+}

--- a/src/main/java/com/momeokji/aiDiarybackend/dto/response/AdminResponseDto.java
+++ b/src/main/java/com/momeokji/aiDiarybackend/dto/response/AdminResponseDto.java
@@ -1,0 +1,27 @@
+package com.momeokji.aiDiarybackend.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.momeokji.aiDiarybackend.entity.Admin;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminResponseDto {
+
+	private String adminId;
+	private LocalDateTime createdAt;
+	private Boolean isValid;
+	private Boolean isSuper;
+
+	public static AdminResponseDto from(Admin admin) {
+		return AdminResponseDto.builder()
+			.adminId(admin.getAdminId())
+			.createdAt(admin.getCreatedAt())
+			.isValid(admin.getIsValid())
+			.isSuper(admin.getIsSuper())
+			.build();
+	}
+}

--- a/src/main/java/com/momeokji/aiDiarybackend/entity/Admin.java
+++ b/src/main/java/com/momeokji/aiDiarybackend/entity/Admin.java
@@ -1,0 +1,68 @@
+package com.momeokji.aiDiarybackend.entity;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@DynamicInsert
+@Table(name = "admin")
+public class Admin {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "admin_id", nullable = false, unique = true)
+	private String adminId;
+
+	@Column(name = "admin_pwd", nullable = false)
+	private String adminPwd;
+
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Column(name = "is_valid", nullable = false, columnDefinition = "TINYINT DEFAULT 0")
+	@ColumnDefault("0")
+	private Boolean isValid;
+
+	@Column(name = "is_super", nullable = false, columnDefinition = "TINYINT DEFAULT 0")
+	@ColumnDefault("0")
+	private Boolean isSuper;
+
+	@Builder
+	public Admin(String adminId, String adminPwd, LocalDateTime createdAt, Boolean isValid, Boolean isSuper) {
+		this.adminId = adminId;
+		this.adminPwd = adminPwd;
+		this.createdAt = createdAt;
+		this.isValid = isValid;
+		this.isSuper = isSuper;
+	}
+
+	public void approve() {
+		this.isValid = true;
+	}
+
+	public void delete(LocalDateTime deletedAt) {
+		this.isValid = false;
+		this.deletedAt = deletedAt;
+	}
+}

--- a/src/main/java/com/momeokji/aiDiarybackend/repository/AdminRepository.java
+++ b/src/main/java/com/momeokji/aiDiarybackend/repository/AdminRepository.java
@@ -1,0 +1,19 @@
+package com.momeokji.aiDiarybackend.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.momeokji.aiDiarybackend.entity.Admin;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+	Optional<Admin> findByAdminId(String adminId);
+
+	Optional<Admin> findByAdminIdAndIsValidTrue(String adminId);
+
+	List<Admin> findByIsSuperFalseAndDeletedAtIsNull();
+}

--- a/src/main/java/com/momeokji/aiDiarybackend/security/JwtAuthFilter.java
+++ b/src/main/java/com/momeokji/aiDiarybackend/security/JwtAuthFilter.java
@@ -1,7 +1,9 @@
 package com.momeokji.aiDiarybackend.security;
 
 import com.momeokji.aiDiarybackend.common.util.JwtUtil;
+import com.momeokji.aiDiarybackend.entity.Admin;
 import com.momeokji.aiDiarybackend.entity.Member;
+import com.momeokji.aiDiarybackend.repository.AdminRepository;
 import com.momeokji.aiDiarybackend.repository.MemberRepository;
 import com.momeokji.aiDiarybackend.service.DiaryService;
 
@@ -24,7 +26,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -35,6 +36,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
 	private final JwtUtil jwt;
 	private final MemberRepository memberRepository;
+	private final AdminRepository adminRepository;
 	private final DiaryService diaryService;
 
 	private static final Set<String> WHITELIST = Set.of(
@@ -64,6 +66,14 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 			return "POST".equalsIgnoreCase(method);
 		}
 
+		if ("/admins".equals(path)) {
+			return "POST".equalsIgnoreCase(method);
+		}
+
+		if ("/admins/login".equals(path)) {
+			return "POST".equalsIgnoreCase(method);
+		}
+
 		return WHITELIST.contains(path);
 	}
 
@@ -85,17 +95,24 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 				}
 
 				String userId = ac.getSubject();
+				String role = resolveRole(ac);
 
-				Member member = memberRepository.findByMemberIdAndIsValidTrue(userId)
+				if (isAdminRole(role)) {
+					adminRepository.findByAdminIdAndIsValidTrue(userId)
+						.orElseThrow(() -> new JwtException("유효하지 않은 관리자입니다."));
+					setAuth(userId, req);
+				} else {
+					memberRepository.findByMemberIdAndIsValidTrue(userId)
 						.orElseThrow(() -> new JwtException("탈퇴한 유저입니다."));
 
-				setAuth(userId, req);
+					setAuth(userId, req);
 
-				//토큰 검증 하면서 api호출 시간 갱신
-				diaryService.updateLastActiveAt(userId);
+					//토큰 검증 하면서 api호출 시간 갱신
+					diaryService.updateLastActiveAt(userId);
+				}
 
 				// refresh 유효성 보장: 없거나/무효/만료면 새로 발급해서 내려줌
-				String ensuredRefresh = ensureValidRefresh(userId, refresh);
+				String ensuredRefresh = ensureValidRefresh(userId, role, refresh);
 
 				res.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + access);
 				res.setHeader("Refresh-Token", ensuredRefresh);
@@ -122,17 +139,28 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 				}
 
 				String userId = rc.getSubject();
+				String role = resolveRole(rc);
 
-				Member member = memberRepository.findByMemberIdAndIsValidTrue(userId)
-					.orElseThrow(() -> new JwtException("탈퇴한 유저입니다."));
+				String newAccess;
+				String newRefresh;
 
-				String newAccess  = jwt.generateAccessToken(member);
-				String newRefresh = jwt.generateRefreshToken(member);
+				if (isAdminRole(role)) {
+					Admin admin = adminRepository.findByAdminIdAndIsValidTrue(userId)
+						.orElseThrow(() -> new JwtException("유효하지 않은 관리자입니다."));
+					newAccess = jwt.generateAdminAccessToken(admin);
+					newRefresh = jwt.generateAdminRefreshToken(admin);
+					setAuth(userId, req);
+				} else {
+					Member member = memberRepository.findByMemberIdAndIsValidTrue(userId)
+						.orElseThrow(() -> new JwtException("탈퇴한 유저입니다."));
+					newAccess = jwt.generateAccessToken(member);
+					newRefresh = jwt.generateRefreshToken(member);
 
-				setAuth(userId, req);
+					setAuth(userId, req);
 
-				//갱신
-				diaryService.updateLastActiveAt(userId);
+					//갱신
+					diaryService.updateLastActiveAt(userId);
+				}
 
 				res.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + newAccess);
 				res.setHeader("Refresh-Token", newRefresh);
@@ -155,9 +183,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 		);
 	}
 
-	private String ensureValidRefresh(String userId, String incomingRefresh) {
+	private String ensureValidRefresh(String userId, String role, String incomingRefresh) {
 		if (incomingRefresh == null) {
-			return issueNewRefresh(userId);
+			return issueNewRefresh(userId, role);
 		}
 
 		try {
@@ -165,22 +193,40 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 			Claims rc = rjws.getPayload();
 
 			if(!"REFRESH".equals(rc.get("typ"))){
-				return issueNewRefresh(userId);
+				return issueNewRefresh(userId, role);
 			}
 			if(!userId.equals(rc.getSubject())){
-				return issueNewRefresh(userId);
+				return issueNewRefresh(userId, role);
+			}
+			if(!role.equals(resolveRole(rc))){
+				return issueNewRefresh(userId, role);
 			}
 			return incomingRefresh; // 유효하므로 그대로 사용
 
 		}catch(JwtException e){
-			return issueNewRefresh(userId);
+			return issueNewRefresh(userId, role);
 		}
 	}
 
-	private String issueNewRefresh(String userId) {
+	private String issueNewRefresh(String userId, String role) {
+		if (isAdminRole(role)) {
+			Admin admin = adminRepository.findByAdminIdAndIsValidTrue(userId)
+				.orElseThrow(() -> new JwtException("유효하지 않은 관리자입니다."));
+			return jwt.generateAdminRefreshToken(admin);
+		}
+
 		Member member = memberRepository.findByMemberIdAndIsValidTrue(userId)
 			.orElseThrow(() -> new JwtException("탈퇴한 유저입니다."));
 		return jwt.generateRefreshToken(member);
+	}
+
+	private String resolveRole(Claims claims) {
+		String role = claims.get("role", String.class);
+		return role == null ? "USER" : role;
+	}
+
+	private boolean isAdminRole(String role) {
+		return "ADMIN".equals(role) || "SUPER_ADMIN".equals(role);
 	}
 
 	private void setAuth(String userId, HttpServletRequest req) {

--- a/src/main/java/com/momeokji/aiDiarybackend/service/AdminAuthService.java
+++ b/src/main/java/com/momeokji/aiDiarybackend/service/AdminAuthService.java
@@ -1,0 +1,109 @@
+package com.momeokji.aiDiarybackend.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.momeokji.aiDiarybackend.common.util.JwtUtil;
+import com.momeokji.aiDiarybackend.dto.request.AdminSignupRequestDto;
+import com.momeokji.aiDiarybackend.dto.response.AdminLoginResultDto;
+import com.momeokji.aiDiarybackend.dto.response.AdminResponseDto;
+import com.momeokji.aiDiarybackend.entity.Admin;
+import com.momeokji.aiDiarybackend.repository.AdminRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAuthService {
+
+	private final AdminRepository adminRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtUtil jwt;
+
+	@Transactional
+	public void signup(AdminSignupRequestDto req) {
+		if (adminRepository.findByAdminId(req.getAdminId()).isPresent()) {
+			throw new IllegalArgumentException("이미 가입된 관리자 계정입니다.");
+		}
+
+		adminRepository.save(
+			Admin.builder()
+				.adminId(req.getAdminId())
+				.adminPwd(passwordEncoder.encode(req.getAdminPwd()))
+				.createdAt(LocalDateTime.now())
+				.isValid(false)
+				.isSuper(false)
+				.build()
+		);
+	}
+
+	@Transactional(readOnly = true)
+	public AdminLoginResultDto login(AdminSignupRequestDto req) {
+		Admin admin = adminRepository.findByAdminId(req.getAdminId())
+			.orElseThrow(() -> new IllegalArgumentException("관리자 계정을 찾을 수 없습니다."));
+
+		if (!Boolean.TRUE.equals(admin.getIsValid())) {
+			throw new IllegalArgumentException("master 관리자 승인 대기 중인 계정입니다.");
+		}
+
+		if (!passwordEncoder.matches(req.getAdminPwd(), admin.getAdminPwd())) {
+			throw new IllegalArgumentException("관리자 비밀번호가 일치하지 않습니다.");
+		}
+
+		return AdminLoginResultDto.builder()
+			.accessToken(jwt.generateAdminAccessToken(admin))
+			.refreshToken(jwt.generateAdminRefreshToken(admin))
+			.isSuper(admin.getIsSuper())
+			.build();
+	}
+
+	@Transactional
+	public void approveAdmin(String superAdminId, String targetAdminId) {
+		validateSuperAdmin(superAdminId);
+
+		Admin targetAdmin = adminRepository.findByAdminId(targetAdminId)
+			.orElseThrow(() -> new IllegalArgumentException("승인할 관리자 계정을 찾을 수 없습니다."));
+
+		if (Boolean.TRUE.equals(targetAdmin.getIsSuper())) {
+			throw new IllegalArgumentException("슈퍼관리자 계정은 승인 대상이 아닙니다.");
+		}
+
+		targetAdmin.approve();
+	}
+
+	@Transactional(readOnly = true)
+	public List<AdminResponseDto> getAdmins(String superAdminId) {
+		validateSuperAdmin(superAdminId);
+
+		return adminRepository.findByIsSuperFalseAndDeletedAtIsNull().stream()
+			.map(AdminResponseDto::from)
+			.toList();
+	}
+
+	@Transactional
+	public void deleteAdmin(String superAdminId, String targetAdminId) {
+		validateSuperAdmin(superAdminId);
+
+		Admin targetAdmin = adminRepository.findByAdminId(targetAdminId)
+			.orElseThrow(() -> new IllegalArgumentException("삭제할 관리자 계정을 찾을 수 없습니다."));
+
+		if (Boolean.TRUE.equals(targetAdmin.getIsSuper())) {
+			throw new IllegalArgumentException("슈퍼관리자 계정은 삭제할 수 없습니다.");
+		}
+
+		targetAdmin.delete(LocalDateTime.now());
+	}
+
+	private void validateSuperAdmin(String adminId) {
+		Admin admin = adminRepository.findByAdminIdAndIsValidTrue(adminId)
+			.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 관리자 계정입니다."));
+
+		if (!Boolean.TRUE.equals(admin.getIsSuper())) {
+			throw new IllegalArgumentException("슈퍼관리자만 접근할 수 있습니다.");
+		}
+	}
+}


### PR DESCRIPTION

## 작업 내용

관리자 페이지 연동을 위한 관리자 인증/관리 API를 구현했습니다.

- 관리자 회원가입 API 추가
- 관리자 로그인 API 추가 및 응답 개선
  - 토큰은 Header로 반환
  - 관리자/슈퍼관리자 UI 분기를 위해 Body에 `isSuper` 반환
- 슈퍼관리자 전용 관리자 목록 조회 API 추가
  - 승인 대기/승인 완료 일반 관리자 모두 조회 가능
- 슈퍼관리자 전용 관리자 승인 API 추가
- 슈퍼관리자 전용 관리자 삭제 API 추가
  - soft delete 방식 적용
- 관리자 목록 응답에서 비밀번호 필드 제거
- 관리자 로그인 응답 DTO 분리
  - Body에는 `isSuper`만 포함되도록 처리

## 테스트

- [x] 관리자 로그인 시 Header에 Access Token / Refresh Token 반환 확인
- [x] 관리자 로그인 시 Body에 `isSuper` 반환 확인
- [x] 관리자 목록 조회 시 승인된 관리자와 승인 대기 관리자 모두 조회 가능 확인
